### PR TITLE
feat: add CI/CD pipeline

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,171 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - "feature/*"
+      - "development"
+      - "master"
+
+  workflow_dispatch:
+    inputs:
+      target_service:
+        type: choice
+        description: "배포할 서비스 선택"
+        options:
+          - api
+          - authentication
+          - batch
+          - collector
+
+jobs:
+  detect_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      auth_changed: ${{ steps.filter.outputs.auth }}
+      api_changed: ${{ steps.filter.outputs.api }}
+      batch_changed: ${{ steps.filter.outputs.batch }}
+      collector_changed: ${{ steps.filter.outputs.collector }}
+      common_changed: ${{ steps.filter.outputs.common }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            auth:
+              - 'authentication/**'
+            api:
+              - 'api/**'
+            batch:
+              - 'batch/**'
+            collector:
+              - 'collector/**'
+            common:
+              - 'application/**'
+              - 'domain/**'
+
+  authentication-test:
+    needs: detect_changes
+    if: github.event_name == 'push' && (
+      needs.detect_changes.outputs.auth_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true'
+      )
+    uses: ./.github/workflows/common-test.yml
+    with:
+      module: "authentication"
+
+  authentication:
+    needs: authentication-test
+    uses: ./.github/workflows/common-build.yml
+    with:
+      module: "authentication"
+      gradle_task: "build"
+      docker_context: "authentication"
+      dockerfile: "authentication/Dockerfile"
+      image_name: "authentication"
+      branch_name: ${{ github.ref_name }}
+    secrets: inherit
+
+  api-test:
+    needs: detect_changes
+    if: github.event_name == 'push' && (
+      needs.detect_changes.outputs.api_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true'
+      )
+    uses: ./.github/workflows/common-test.yml
+    with:
+      module: "api"
+  api:
+    needs: api-test
+    uses: ./.github/workflows/common-build.yml
+    with:
+      module: "api"
+      gradle_task: "build"
+      docker_context: "api"
+      dockerfile: "api/Dockerfile"
+      image_name: "api"
+      branch_name: ${{ github.ref_name }}
+    secrets: inherit
+
+  batch-test:
+    needs: detect_changes
+    if: github.event_name == 'push' && (
+      needs.detect_changes.outputs.batch_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true'
+      )
+    uses: ./.github/workflows/common-test.yml
+    with:
+      module: "batch"
+  batch:
+    needs: batch-test
+    uses: ./.github/workflows/common-build.yml
+    with:
+      module: "batch"
+      gradle_task: "build"
+      docker_context: "batch"
+      dockerfile: "batch/Dockerfile"
+      image_name: "batch"
+      branch_name: ${{ github.ref_name }}
+    secrets: inherit
+
+  collector-test:
+    needs: detect_changes
+    if: github.event_name == 'push' && (
+      needs.detect_changes.outputs.collector_changed == 'true' ||
+      needs.detect_changes.outputs.common_changed == 'true'
+      )
+    uses: ./.github/workflows/common-test.yml
+    with:
+      module: "collector"
+  collector:
+    needs: collector-test
+    uses: ./.github/workflows/common-build.yml
+    with:
+      module: "collector"
+      gradle_task: "bootJar"
+      docker_context: "."
+      dockerfile: "collector/Dockerfile"
+      image_name: "collector"
+      branch_name: ${{ github.ref_name }}
+    secrets: inherit
+
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create SSH key file
+        run: |
+          echo "${{ secrets.EC2_KEY }}" > ec2_key.pem
+          chmod 600 ec2_key.pem
+      - name: Upload deploy files
+        run: |
+          scp -i ec2_key.pem -o StrictHostKeyChecking=no \
+            deploy/docker-compose.yml \
+            ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/tech-gather/
+          
+          scp -i ec2_key.pem -o StrictHostKeyChecking=no \
+            deploy/deploy.sh \
+            ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/tech-gather/
+
+          scp -i ec2_key.pem -o StrictHostKeyChecking=no deploy/services.json \
+            ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/tech-gather/
+
+      - name: Deploy on EC2
+        run: |
+          TARGET="${{ github.event.inputs.target_service }}"
+          
+          ssh -i ec2_key.pem -o StrictHostKeyChecking=no ec2-user@${{ secrets.EC2_HOST }} "
+            cd /home/ec2-user/tech-gather/
+            chmod +x deploy.sh
+          
+            docker login -u '${{ secrets.DOCKER_USERNAME }}' -p '${{ secrets.DOCKER_PASSWORD }}'
+
+            export DOCKER_REPO=${{ secrets.DOCKER_REPO }};
+            ./deploy.sh $TARGET
+          "

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -1,0 +1,66 @@
+name: Common Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      module:
+        required: true
+        type: string
+      gradle_task:
+        required: true
+        type: string
+      docker_context:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+      image_name:
+        required: true
+        type: string
+      branch_name:
+        required: true
+        type: string
+    secrets:
+      DOCKER_REPO:
+        required: true
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Gradle Build (skip tests)
+        run: |
+          ./gradlew :${{ inputs.module }}:${{ inputs.gradle_task }} -x test --no-daemon
+
+      - name: Docker Build
+        if: inputs.branch_name == 'development' || inputs.branch_name == 'master'
+        run: |
+          docker build \
+            -f ${{ inputs.dockerfile }} \
+            -t ${{ secrets.DOCKER_REPO }}:${{ inputs.image_name }}-latest \
+            -t ${{ secrets.DOCKER_REPO }}:${{ inputs.image_name }}-${{ github.sha }} \
+            ${{ inputs.docker_context }}
+
+      - name: DockerHub Login
+        if: inputs.branch_name == 'master'
+        run: |
+          docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
+
+      - name: Docker Push
+        if: inputs.branch_name == 'master'
+        run: |
+          docker push ${{ secrets.DOCKER_REPO }}:${{ inputs.image_name }}-latest
+          docker push ${{ secrets.DOCKER_REPO }}:${{ inputs.image_name }}-${{ github.sha }}

--- a/.github/workflows/common-test.yml
+++ b/.github/workflows/common-test.yml
@@ -1,0 +1,24 @@
+name: Common Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      module:
+        required: true
+        type: string
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Run Tests
+        run: |
+          ./gradlew :${{ inputs.module }}:test --no-daemon

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+TARGET="$1"
+
+
+if [ -z "$TARGET" ]; then
+  echo "Usage: ./deploy.sh <service-name>"
+  exit 1
+fi
+
+cd /home/ec2-user/tech-gather
+export DOCKER_REPO="${DOCKER_REPO}"
+
+echo "Stopping $TARGET..."
+docker-compose stop $TARGET
+
+echo "Removing $TARGET container..."
+docker-compose rm -f $TARGET
+
+echo "Removing old $TARGET images..."
+docker images --format "{{.Repository}}:{{.Tag}} {{.ID}}" \
+ | awk -v target="$DOCKER_REPO:${TARGET}" '$1 ~ "^"target {print $2}' \
+ | xargs -r docker rmi -f
+
+echo "Pulling latest image.. "
+docker-compose pull $TARGET
+
+echo "Starting $TARGET..."
+docker-compose up -d $TARGET
+
+CONFIG="/home/ec2-user/tech-gather/services.json"
+PORT=$(jq -r ".\"$TARGET\".port" $CONFIG)
+HEALTH_PATH=$(jq -r ".\"$TARGET\".health" $CONFIG)
+
+HEALTH_URL="http://localhost:${PORT}${HEALTH_PATH}"
+
+for i in {1..20}; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL")
+  if [[ "$STATUS" == "200" ]]; then
+    echo "Health check OK!"
+    exit 0
+  fi
+  echo "Health check failed ($STATUS)… retry $i/20"
+  sleep 3
+done
+
+echo "Deployment completed"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.8"
+
+services:
+  api:
+    mem_limit: 450m
+    memswap_limit: 700m
+    image: "${DOCKER_REPO}:api-latest"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: api
+    ports:
+      - "8888:8888"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      JAVA_TOOL_OPTIONS: >
+        -XX:MaxRAMPercentage=65
+        -XX:InitialRAMPercentage=30
+    restart: always
+
+  authentication:
+    mem_limit: 300m
+    memswap_limit: 500m
+    image: "${DOCKER_REPO}:authentication-latest"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    container_name: authentication
+    ports:
+      - "5080:5080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      JAVA_TOOL_OPTIONS: >
+        -XX:MaxRAMPercentage=60
+        -XX:InitialRAMPercentage=25
+    restart: always

--- a/deploy/services.json
+++ b/deploy/services.json
@@ -1,0 +1,9 @@
+{
+  "api": {
+    "port": 8888,
+    "health": "/api/actuator/health" },
+  "authentication": {
+    "port": 5080,
+    "health": "/actuator/health"
+  }
+}


### PR DESCRIPTION
- GitHub Actions 빌드 파이프라인 리팩토링
    - 중복 build job을 common-build.yml reusable workflow로 분리
- 배포 안정성 개선
    - 빌드와 테스트 분리
    - services.json 기반 health check 대상 관리 추가
    - 배포 시 auth, api 모듈 메모리 제한 설정
- 운영 리소스 관리 개선
    - 컨테이너 로그 최대 크기 30MB로 제한
    - 배포 시 기존 Docker 이미지 정리하여 디스크 사용량 관리